### PR TITLE
dom选择器bug

### DIFF
--- a/dist/lettuce.js
+++ b/dist/lettuce.js
@@ -42,7 +42,7 @@ window.L = Lettuce.dom = function(selector, context, undefined) {
 	// now pass the selector without the key/first character
 	var el = (((context === undefined) ? document: context)[matches](selector.slice(1)));
 	// if there is one element than return the 0 element
-	return ((el.length < 2) ? el[0]: el);
+	return ((el && el.length < 2) ? el[0]: el);
 };
 
 /*     (c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors

--- a/src/dom.js
+++ b/src/dom.js
@@ -14,5 +14,5 @@ window.L = Lettuce.dom = function(selector, context, undefined) {
 	// now pass the selector without the key/first character
 	var el = (((context === undefined) ? document: context)[matches](selector.slice(1)));
 	// if there is one element than return the 0 element
-	return ((el.length < 2) ? el[0]: el);
+	return ((el && el.length < 2) ? el[0]: el);
 };


### PR DESCRIPTION
当传递一个页面不存在的id选择器时，会报错。
